### PR TITLE
use sys.executable

### DIFF
--- a/aktools/cli.py
+++ b/aktools/cli.py
@@ -4,6 +4,7 @@
 Date: 2022/9/27 19:05
 Desc: CLI 命令文件
 """
+import sys
 from pathlib import Path
 from subprocess import run
 from typing import Optional
@@ -40,7 +41,7 @@ def main(
 ) -> None:
     app_dir = Path(__file__).parent
     order_str = (
-        f"python -m uvicorn main:app --host {host} --port {port} --app-dir {app_dir}"
+        f"{sys.executable} -m uvicorn main:app --host {host} --port {port} --app-dir {app_dir}"
     )
     typer.echo(
         f"请访问：http://{host}:{port}/version 来获取最新的库版本信息，确保使用最新版本的 AKShare 和 AKTools"


### PR DESCRIPTION
对于这个问题

https://github.com/akfamily/aktools/issues/158

当用 python3 来运行的时候 硬编码了 python 实际指向了 python2

```
[root@VM-8-3-centos ~]# python3 -m aktools
请访问：http://127.0.0.1:8080/version 来获取最新的库版本信息，确保使用最新版本的 AKShare 和 AKTools
当前的 AKTools 版本为：0.0.90，AKShare 版本为：1.17.56
点击打开 HTTP API 主页：http://127.0.0.1:8080/
点击打开接口导览：http://127.0.0.1:8080/docs
/usr/bin/python: No module named uvicorn
```